### PR TITLE
`setExtreme` events and chart `refresh` fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dqvue",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "description": "",
     "main": "./dist/dqvue.js",
     "types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dqvue",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "",
     "main": "./dist/dqvue.js",
     "types": "./index.d.ts",
@@ -42,8 +42,5 @@
         "webpack-bundle-analyzer": "^2.9.2",
         "wnumb": "^1.1.0",
         "yargs": "9.0.1"
-    },
-    "dependencies": {
-        "vue-template-compiler": "^2.5.13"
     }
 }

--- a/poi.config.js
+++ b/poi.config.js
@@ -28,9 +28,7 @@ module.exports = {
         })
     ],
     extendWebpack(config) {
-        config.resolve.alias
-            .set('vue$', 'vue/dist/vue.esm.js') // vue.esm include template compiler; without it all templates need to be pre-compiled
-            .set('highcharts', 'highcharts/highcharts.src.js'); // include non-minified highcharts into the dev build
+        config.resolve.alias.set('vue$', 'vue/dist/vue.esm.js'); // vue.esm include template compiler; without it all templates need to be pre-compiled
 
         config.output.set('library', 'DQV').set('libraryExport', 'default'); // exposes the default export directly on the global library variable: https://webpack.js.org/configuration/output/#output-libraryexport
 
@@ -40,6 +38,7 @@ module.exports = {
     karma: {
         mime: {
             'text/x-typescript': ['ts']
-        }
+        },
+        karmaTypescriptConfig: undefined
     }
 };

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -6,7 +6,7 @@ import { DVSection } from './../classes/section';
 import { DVChart } from './../classes/chart';
 import { sections, charts } from './../store/main';
 
-import { sectionCreatedSubject, chartCreatedSubject } from './../observable-bus';
+import { sectionCreated, chartCreated } from './../observable-bus';
 
 import { Observable } from 'rxjs/Observable';
 
@@ -73,8 +73,8 @@ export default {
     Section: DVSection,
     Chart: DVChart,
 
-    sectionCreated: sectionCreatedSubject.asObservable(),
-    chartCreated: chartCreatedSubject.asObservable(),
+    sectionCreated: sectionCreated.asObservable(),
+    chartCreated: chartCreated.asObservable(),
 
     get sections(): { [name: string]: DVSection } {
         // TODO: return a clone instead of original object so users can't mess with it

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -32,6 +32,15 @@ function importHighcharts(): void {
 
 // semi-public functionality not exposed on the HC declarations
 export namespace DVHighcharts {
+    export interface Options extends Highcharts.Options {
+        exporting: ExportingOptions;
+    }
+
+    export interface ExportingOptions extends Highcharts.ExportingOptions {
+        // `menuItemDefinitions` is not included in the `ExportingOptions` type
+        menuItemDefinitions: { [name: string]: MenuItem | null };
+    }
+
     export interface ChartObject extends Highcharts.ChartObject {
         // https://api.highcharts.com/highcharts/chart.resetZoomButton
         resetZoomButton: Highcharts.ElementObject | undefined;
@@ -49,6 +58,8 @@ export namespace DVHighcharts {
         // https://api.highcharts.com/highcharts/xAxis.minRange
         minRange: number;
     }
+
+    export interface AxisEvent extends Highcharts.AxisEvent {}
 
     // https://api.highcharts.com/highcharts/exporting.menuItemDefinitions
     export interface MenuItem extends Highcharts.MenuItem {

--- a/src/classes/section.ts
+++ b/src/classes/section.ts
@@ -6,7 +6,7 @@ import { DVChart } from './chart';
 import Chart from './../components/chart.vue';
 import ChartTable from './../components/chart-table.vue';
 
-import { sectionCreatedSubject } from './../observable-bus';
+import { sectionCreated } from './../observable-bus';
 
 import { isPromise, isFunction, isString, isObject } from './../utils';
 // TODO: constrain logging to 'warn' in production builds
@@ -60,7 +60,7 @@ export class DVSection {
         }
 
         // push the new section through the stream
-        sectionCreatedSubject.next(this);
+        sectionCreated.next({ sectionId: this.id, dvsection: this });
 
         if (mount) {
             this._mount = mount;
@@ -287,6 +287,7 @@ export class DVSection {
         }
 
         // TODO: when dismouning a section, remove all the chart tables originating from charts in this section, even ones that are in different sections
+        // TODO: maybe instead of removing all the chart tables in other sections, just hide them and reactivate them if the section with their parent chart is remounted
         this._vm.$destroy();
         this._isMounted = false;
 

--- a/src/components/chart-table.vue
+++ b/src/components/chart-table.vue
@@ -99,18 +99,10 @@ export default class ChartTable extends Vue {
         // --- TODO: deprecated; should be removed when `dv-auto-render` attribute is removed
         if (this.autoRender) {
             chartRendered.filter(this._filterStream, this).subscribe(this.generateTable);
-            /* Chart.rendered
-                .filter((event: RenderedEvent) => event.chartId === this.chartId)
-                .subscribe(() => this.generateTable()); */
         }
         // ---
 
         chartViewData.filter(this._filterStream, this).subscribe(this.generateTable);
-        /* Chart.viewData
-            .filter((event: ViewDataEvent) => {
-                return event.chartId === this.chartId;
-            })
-            .subscribe(() => this.generateTable()); */
     }
 
     generateTable(): void {

--- a/src/components/chart-table.vue
+++ b/src/components/chart-table.vue
@@ -10,7 +10,15 @@ import uniqid from 'uniqid';
 import loglevel from 'loglevel';
 import api from './../api/main';
 
-import Chart, { RenderedEvent, ViewDataEvent } from './../components/chart.vue';
+import {
+    chartRendered,
+    chartViewData,
+    ChartEvent,
+    ChartRenderedEvent,
+    ChartViewDataEvent
+} from './../observable-bus';
+
+//import Chart, { RenderedEvent, ViewDataEvent } from './../components/chart.vue';
 import { charts } from './../store/main';
 
 import 'rxjs/add/operator/filter';
@@ -48,15 +56,17 @@ export default class ChartTable extends Vue {
     created(): void {
         if (!this.chartId) {
             log.error(
-                `[chart-table='${this.id}' section='${this
-                    .rootSectionId}'] table cannot be linked because it is missing a parent chart id`
+                `[chart-table='${this.id}' section='${
+                    this.rootSectionId
+                }'] table cannot be linked because it is missing a parent chart id`
             );
         }
 
         if (!charts[this.chartId]) {
             log.error(
-                `[chart-table='${this.id}' chart='${this.chartId}' section='${this
-                    .rootSectionId}'] referenced chart does not exist`
+                `[chart-table='${this.id}' chart='${this.chartId}' section='${
+                    this.rootSectionId
+                }'] referenced chart does not exist`
             );
             return;
         }
@@ -88,25 +98,28 @@ export default class ChartTable extends Vue {
 
         // --- TODO: deprecated; should be removed when `dv-auto-render` attribute is removed
         if (this.autoRender) {
-            Chart.rendered
+            chartRendered.filter(this._filterStream, this).subscribe(this.generateTable);
+            /* Chart.rendered
                 .filter((event: RenderedEvent) => event.chartId === this.chartId)
-                .subscribe(() => this.generateTable());
+                .subscribe(() => this.generateTable()); */
         }
         // ---
 
-        Chart.viewData
+        chartViewData.filter(this._filterStream, this).subscribe(this.generateTable);
+        /* Chart.viewData
             .filter((event: ViewDataEvent) => {
                 return event.chartId === this.chartId;
             })
-            .subscribe(() => this.generateTable());
+            .subscribe(() => this.generateTable()); */
     }
 
     generateTable(): void {
         // render table can only be called after the chart has been rendered
         if (!this.dvchart.highchart) {
             log.warn(
-                `[chart-table='${this.id}' chart='${this
-                    .chartId}'] something's wrong - trying to render the table before chart is ready`
+                `[chart-table='${this.id}' chart='${
+                    this.chartId
+                }'] something's wrong - trying to render the table before chart is ready`
             );
             return;
         }
@@ -126,11 +139,13 @@ export default class ChartTable extends Vue {
             this.highchartsDataTable
         );
     }
+
+    private _filterStream(event: ChartEvent): boolean {
+        return event.chartId === this.chartId;
+    }
 }
 </script>
 
 <style lang="scss" scoped>
 
 </style>
-
-

--- a/src/components/chart.vue
+++ b/src/components/chart.vue
@@ -26,6 +26,8 @@ import {
 import { DVChart } from './../classes/chart';
 import { charts } from './../store/main';
 
+import { isArray } from './../utils';
+
 import ChartSlider from './../components/chart-slider.vue';
 
 const log: loglevel.Logger = loglevel.getLogger('dv-chart');
@@ -33,35 +35,12 @@ const log: loglevel.Logger = loglevel.getLogger('dv-chart');
 const DV_CHART_CONTAINER_ELEMENT = '[dv-chart-container]';
 const DV_CHART_TABLE_CONTAINER_ELEMENT = '[dv-chart-table-container]';
 
-export type RenderedEvent = { chartId: string; highchartObject: DVHighcharts.ChartObject };
-export type ViewDataEvent = { chartId: string };
-export type SetExtremesEvent = {
-    chartId: string;
-    axis: 'xAxis' | 'yAxis';
-    max: number;
-    min: number;
-};
-
-// `menuItemDefinitions` is not included in default Highcharts exporting options types
-interface EnhancedExportingOptions extends Highcharts.ExportingOptions {
-    menuItemDefinitions: { [name: string]: DVHighcharts.MenuItem | null };
-}
-
 @Component({
     components: {
         'dv-chart-slider': ChartSlider
     }
 })
 export default class Chart extends Vue {
-    /* private static _rendered: Subject<RenderedEvent> = new Subject<RenderedEvent>();
-    static rendered = Chart._rendered.asObservable();
-
-    private static _viewData: Subject<ViewDataEvent> = new Subject<ViewDataEvent>();
-    static viewData = Chart._viewData.asObservable();
-
-    private static _setExtremes: Subject<SetExtremesEvent> = new Subject<SetExtremesEvent>();
-    static setExtremes = Chart._setExtremes.asObservable(); */
-
     dvchart: DVChart;
     isLoading: boolean = true;
 
@@ -155,62 +134,81 @@ export default class Chart extends Vue {
     renderChart(): void {
         log.info(`[chart='${this.id}'] rendering chart`);
 
-        // merge the custom `viewData` export option into the chart config
-        // if no exporting options exist, they will be created
-        // if the config author has specified `viewData` export option, it will not be overwritten
-        this.dvchart.config!.exporting = deepmerge.all([
-            {
-                menuItemDefinitions: {
-                    viewData: this._viewDataExportOption
-                }
-            } as EnhancedExportingOptions,
-            (this.dvchart.config!.exporting || {}) as Object
-        ]) as Highcharts.ExportingOptions;
+        // create a deep copy of the original config for reference
+        const originalConfig: DVHighcharts.Options = deepmerge({}, this.dvchart.config);
 
-        // TODO: handle yAxis
-        // TODO: if a 'setExtreme' event handler is already specified on the in the chart config, wrap it and execute it after the main handler
-        this.dvchart.config!.xAxis = deepmerge.all([
-            {
+        const originalViewDataOption: DVHighcharts.MenuItem | undefined = originalConfig.exporting
+            .menuItemDefinitions.viewData!;
+
+        // create an update snippet for the config based on the DQV options (table generation is the only one for now)
+        const configUpdates: DVHighcharts.Options = {
+            exporting: {
+                menuItemDefinitions: {
+                    viewData:
+                        // if no exporting options exist (`undefined` only, `null` has meaning in chart config - hide option), an internal one will be supplied
+                        // if the config author has specified `viewData` export option, it will not be overwritten
+                        typeof originalViewDataOption === 'undefined'
+                            ? this._viewDataExportOption
+                            : originalViewDataOption
+                }
+            },
+            // TODO: handle yAxis
+            // TODO: handle multipl x axes
+            // it's possible to specify several x axes for a chart
+            // in this case, each axis's options needs to be overwritten separately
+
+            /* const axes = isArray<Highcharts.AxisOptions>(originalConfig.xAxis)
+                ? originalConfig.xAxis
+                : [originalConfig.xAxis];
+
+            axes.forEach((axis: Highcharts.AxisOptions) =>
+                this._setExtremesHandler(event, axis.events!.setExtremes!)
+            ); */
+            xAxis: {
                 events: {
-                    setExtremes: (event: { max: number; min: number }) => {
-                        chartSetExtremes.next({
-                            chartId: this.id,
-                            dvchart: this.dvchart,
-                            axis: 'xAxis',
-                            max: event.max,
-                            min: event.min
-                        });
-                        /* Chart._setExtremes.next({
-                            chartId: this.id,
-                            axis: 'xAxis',
-                            max: event.max,
-                            min: event.min
-                        }); */
+                    setExtremes: (event: Highcharts.AxisEvent) => {
+                        this._setExtremesHandler(
+                            event,
+                            (<Highcharts.AxisOptions>originalConfig.xAxis!).events!.setExtremes!
+                        );
                     }
                 }
-            } as Object,
-            (this.dvchart.config!.xAxis || {}) as Object
-        ]) as Object;
+            }
+        };
+
+        // update the original config
+        const modifiedConfig: DVHighcharts.Options = deepmerge(this.dvchart.config, configUpdates);
 
         // create an actual Highcharts object
-        this.highchartObject = api.Highcharts.chart(this._chartContainer, this.dvchart
-            .config as Highcharts.Options);
+        this.highchartObject = api.Highcharts.chart(this._chartContainer, modifiedConfig);
         this.isLoading = false;
 
+        // push an event into the chart rendered stream
         chartRendered.next({
             chartId: this.id,
             dvchart: this.dvchart,
             highchartObject: this.highchartObject as DVHighcharts.ChartObject
         });
 
-        /* Chart._rendered.next({
-            chartId: this.id,
-            highchartObject: this.highchartObject as DVHighcharts.ChartObject
-        }); */
-
         if (this.autoGenerateTable) {
             this.simulateViewDataClick();
         }
+    }
+
+    // execute the original `setExtremes` handler specified in the chart config and push a `setExtremes` event into the corresponding stream
+    private _setExtremesHandler(
+        event: DVHighcharts.AxisEvent,
+        originalHandler: (event: DVHighcharts.AxisEvent) => void
+    ): void {
+        originalHandler.call(event.target, event);
+
+        chartSetExtremes.next({
+            chartId: this.id,
+            dvchart: this.dvchart,
+            axis: 'xAxis',
+            max: event.max,
+            min: event.min
+        });
     }
 }
 </script>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -151,7 +151,7 @@
                         '        <dv-chart></dv-chart>' +
                         '        <dv-chart id="dfdf"></dv-chart>' +
 
-                        '        [{{ count }}]' +
+                        '        [{{ count }}] <span id="nuclear-extreme"></span>' +
                         '    </dv-section>'
                         ;
 
@@ -291,7 +291,13 @@
                                     return this.value; // clean, unformatted number for year
                                 }
                             },
-                            type: 'datetime'
+                            type: 'datetime',
+                            events: {
+                                setExtremes: function (event) {
+                                    console.log('nuclear `setExtremes` external handle');
+                                    document.getElementById('nuclear-extreme').innerHTML = Math.random().toFixed(2);
+                                }
+                            }
                         },
                         yAxis: {
                             title: {

--- a/src/observable-bus.ts
+++ b/src/observable-bus.ts
@@ -1,9 +1,55 @@
 import { Subject } from 'rxjs/Subject';
 
+import { DVHighcharts } from './api/main';
+
 import { DVSection } from './classes/section';
 import { DVChart } from './classes/chart';
 
-const sectionCreatedSubject: Subject<DVSection> = new Subject<DVSection>();
-const chartCreatedSubject: Subject<DVChart> = new Subject<DVChart>();
+// #region chart events
 
-export { sectionCreatedSubject, chartCreatedSubject };
+export interface ChartEvent {
+    chartId: string;
+    dvchart: DVChart;
+}
+
+export interface ChartCreatedEvent extends ChartEvent {}
+
+export interface ChartRenderedEvent extends ChartEvent {
+    highchartObject: DVHighcharts.ChartObject;
+}
+
+export interface ChartConfigUpdatedEvent extends ChartEvent {}
+
+export interface ChartViewDataEvent extends ChartEvent {}
+
+export interface ChartSetExtremesEvent extends ChartEvent {
+    axis: 'xAxis' | 'yAxis';
+    max: number;
+    min: number;
+}
+
+export const chartCreated: Subject<ChartCreatedEvent> = new Subject<ChartCreatedEvent>();
+export const chartRendered: Subject<ChartRenderedEvent> = new Subject<ChartRenderedEvent>();
+export const chartConfigUpdated: Subject<ChartConfigUpdatedEvent> = new Subject<
+    ChartConfigUpdatedEvent
+>();
+export const chartViewData: Subject<ChartViewDataEvent> = new Subject<ChartViewDataEvent>();
+export const chartSetExtremes: Subject<ChartSetExtremesEvent> = new Subject<
+    ChartSetExtremesEvent
+>();
+
+// #endregion
+
+// #region section events
+
+export interface SectionEvent {
+    sectionId: string;
+}
+
+export interface SectionCreatedEvent extends SectionEvent {
+    dvsection: DVSection;
+}
+
+export const sectionCreated: Subject<SectionCreatedEvent> = new Subject<SectionCreatedEvent>();
+
+// #endregion

--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -1,7 +1,12 @@
 import { DVSection } from './../classes/section';
 import { DVChart } from './../classes/chart';
 
-import { sectionCreatedSubject, chartCreatedSubject } from './../observable-bus';
+import {
+    sectionCreated,
+    chartCreated,
+    SectionCreatedEvent,
+    ChartCreatedEvent
+} from './../observable-bus';
 
 import { isString } from './../utils';
 
@@ -13,26 +18,26 @@ const charts: { [name: string]: DVChart } = {};
 /**
  * Adds a DV Section to the reference container if another section with the same id does not exist.
  */
-function addSection(section: DVSection): void {
-    if (sections[section.id]) {
+function addSection(event: SectionCreatedEvent): void {
+    if (sections[event.sectionId]) {
         return;
     }
 
-    sections[section.id] = section;
+    sections[event.sectionId] = event.dvsection;
 }
 
 /**
  * Adds a DV Chart to the reference container if another chart with the same id does not exist.
  */
-function addChart(chart: DVChart): void {
-    if (charts[chart.id]) {
+function addChart(event: ChartCreatedEvent): void {
+    if (charts[event.chartId]) {
         return;
     }
 
-    charts[chart.id] = chart;
+    charts[event.chartId] = event.dvchart;
 }
 
-sectionCreatedSubject.subscribe(addSection);
-chartCreatedSubject.subscribe(addChart);
+sectionCreated.subscribe(addSection);
+chartCreated.subscribe(addChart);
 
 export { sections, charts };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,10 @@ function isPromise<T>(x: any): x is Promise<T> {
     );
 }
 
+function isArray<T>(x: any): x is T[] {
+    return Array.isArray(x);
+}
+
 enum keyCodes {
     'BREAK' = 3,
     'BACKSPACE_/_DELETE' = 8,
@@ -174,4 +178,4 @@ enum keyCodes {
     'TOGGLE_TOUCHPAD' = 255
 }
 
-export { isFunction, isString, isObject, isPromise, keyCodes };
+export { isFunction, isString, isObject, isPromise, isArray, keyCodes };


### PR DESCRIPTION
- honours `setExtremes` event handles set in the chart config
- correctly keeps track of the Highcharts instance when the chart is refreshed to user for zoom slider udates

Closes #9, #10